### PR TITLE
fix: reference to an outdated curl package in the build container

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -143,7 +143,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}
             type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=1.13.7-SNAPSHOT,enable=${{ github.event.inputs.deploy_docker == 'true' || github.ref == format('refs/heads/{0}', 'main') }}
+            type=raw,value=1.14.23-SNAPSHOT,enable=${{ github.event.inputs.deploy_docker == 'true' || github.ref == format('refs/heads/{0}', 'main') }}
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
 
       # build in any case, but push only main and version tag settings

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ kubectl wait --namespace ingress-nginx \
   --selector=app.kubernetes.io/component=controller \
   --timeout=90s
 # transfer images
-kind load docker-image docker.io/tractusx/aas-bridge:1.13.7-SNAPSHOT --name ka
+kind load docker-image docker.io/tractusx/aas-bridge:1.14.23-SNAPSHOT --name ka
 # run container test
 ct install --charts charts/aas-bridge
 ```

--- a/charts/aas-bridge/Chart.yaml
+++ b/charts/aas-bridge/Chart.yaml
@@ -30,7 +30,7 @@ home: https://github.com/eclipse-tractusx/knowledge-agents-aas-bridge/
 sources:
   - https://github.com/eclipse-tractusx/knowledge-agents-aas-bridge/tree/main/sparql-aas
 type: application
-appVersion: "1.13.7-SNAPSHOT"
-version: 1.13.7-SNAPSHOT
+appVersion: "1.14.23-SNAPSHOT"
+version: 1.14.23-SNAPSHOT
 maintainers:
   - name: 'Tractus-X Knowledge Agents Team'

--- a/charts/aas-bridge/README.md
+++ b/charts/aas-bridge/README.md
@@ -21,7 +21,7 @@
 
 # aas-bridge
 
-![Version: 1.13.7-SNAPSHOT](https://img.shields.io/badge/Version-0.13.6--SNAPSHOT-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.13.7-SNAPSHOT](https://img.shields.io/badge/AppVersion-0.13.6--SNAPSHOT-informational?style=flat-square)
+![Version: 1.14.23-SNAPSHOT](https://img.shields.io/badge/Version-0.13.6--SNAPSHOT-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.14.23-SNAPSHOT](https://img.shields.io/badge/AppVersion-0.13.6--SNAPSHOT-informational?style=flat-square)
 
 A Helm chart for the Tractus-X Knowledge Agents AAS Bridge which is a container to provide an AAS server/registry on top of a knowledge graph/SPARQL landscape.
 
@@ -32,7 +32,7 @@ This chart has no prerequisites.
 ## TL;DR
 ```shell
 $ helm repo add eclipse-tractusx https://eclipse-tractusx.github.io/charts/dev
-$ helm install my-release eclipse-tractusx/aas-bridge --version 1.13.7-SNAPSHOT
+$ helm install my-release eclipse-tractusx/aas-bridge --version 1.14.23-SNAPSHOT
 ```
 
 ## Maintainers

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.eclipse.tractusx.agents</groupId>
     <artifactId>aas</artifactId>
-    <version>1.13.7-SNAPSHOT</version>
+    <version>1.14.23-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Tractus-X Knowledge Agents AAS Bridges</name>
     <description>Provides Implementations for Bridging Knowledge Agents and AAS</description>

--- a/sparql-aas/README.md
+++ b/sparql-aas/README.md
@@ -87,7 +87,7 @@ mvn -s ../../../settings.xml install -Pwith-docker-image
 Alternatively, after a sucessful [build](#building) the docker image of the Sparql-To-AAS bridge is created using
 
 ```console
-docker build -t tractusx/aas-bridge:1.13.7-SNAPSHOT -f src/main/docker/Dockerfile .
+docker build -t tractusx/aas-bridge:1.14.23-SNAPSHOT -f src/main/docker/Dockerfile .
 ```
 
 To run the docker image against a local knowledge graph, you could invoke this command
@@ -97,7 +97,7 @@ docker run -p 8443:8443 \
   -v $(pwd)/resources:/app/resources \
   -e "PROVIDER_SPARQL_ENDPOINT=http://oem-provider-agent:8082/sparql" \
   -e "PROVIDER_CREDENTIAL_BASIC=Basic Zm9vOg==" \
-  tractusx/aas-bridge:1.13.7-SNAPSHOT
+  tractusx/aas-bridge:1.14.23-SNAPSHOT
 ````
 
 Afterwards, you should be able to access the [local AAS endpoint](https://localhost:8443/) via REST

--- a/sparql-aas/pom.xml
+++ b/sparql-aas/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.eclipse.tractusx.agents</groupId>
         <artifactId>aas</artifactId>
-        <version>1.13.7-SNAPSHOT</version>
+        <version>1.14.23-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/sparql-aas/src/main/docker/Dockerfile
+++ b/sparql-aas/src/main/docker/Dockerfile
@@ -24,7 +24,7 @@ ENV OTEL_AGENT_LOCATION "https://github.com/open-telemetry/opentelemetry-java-in
 
 HEALTHCHECK NONE
 
-RUN apk update && apk add curl=8.5.0-r0 --no-cache
+RUN apk update && apk add curl=8.9.0-r0 --no-cache
 RUN curl -L --proto "=https" -sSf ${OTEL_AGENT_LOCATION} --output /tmp/opentelemetry-javaagent.jar
 
 FROM eclipse-temurin:22_36-jre-alpine

--- a/upgrade_version.sh
+++ b/upgrade_version.sh
@@ -16,7 +16,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-OLD_VERSION=1.13.7-SNAPSHOT
+OLD_VERSION=1.14.23-SNAPSHOT
 echo Upgrading from $OLD_VERSION to $1
 PATTERN=s/$OLD_VERSION/$1/g
 LC_ALL=C


### PR DESCRIPTION
<!--
 * Copyright (c) 2023,2024 T-Systems International GmbH 
 * Copyright (c) 2023 SAP SE 
 * Copyright (c) 2023,2024 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Apache License, Version 2.0 which is available at
 * https://www.apache.org/licenses/LICENSE-2.0.
 *
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 * License for the specific language governing permissions and limitations
 * under the License.
 *
 * SPDX-License-Identifier: Apache-2.0
-->

## WHAT

Port of a fix in the release branch

## WHY

docker build stage outdated.

## FURTHER NOTES

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

Closes # <-- _insert Issue number if one exists_
